### PR TITLE
fix: the "check_slab() succeeded!" does not in  lab5-lab8's grade.sh,…

### DIFF
--- a/labcodes_answer/lab5_result/tools/grade.sh
+++ b/labcodes_answer/lab5_result/tools/grade.sh
@@ -338,7 +338,6 @@ default_check() {
     'PDE(001) fac00000-fb000000 00400000 -rw'                   \
     '  |-- PTE(000e0) faf00000-fafe0000 000e0000 urw'           \
     '  |-- PTE(00001) fafeb000-fafec000 00001000 -rw'		\
-    'check_slab() succeeded!'					\
     'check_vma_struct() succeeded!'                             \
     'page fault at 0x00000100: K/W [no page found].'            \
     'check_pgfault() succeeded!'                                \

--- a/labcodes_answer/lab6_result/tools/grade.sh
+++ b/labcodes_answer/lab6_result/tools/grade.sh
@@ -338,7 +338,6 @@ default_check() {
     'PDE(001) fac00000-fb000000 00400000 -rw'                   \
     '  |-- PTE(000e0) faf00000-fafe0000 000e0000 urw'           \
     '  |-- PTE(00001) fafeb000-fafec000 00001000 -rw'		\
-    'check_slab() succeeded!'					\
     'check_vma_struct() succeeded!'                             \
     'page fault at 0x00000100: K/W [no page found].'            \
     'check_pgfault() succeeded!'                                \

--- a/labcodes_answer/lab7_result/tools/grade.sh
+++ b/labcodes_answer/lab7_result/tools/grade.sh
@@ -338,7 +338,6 @@ default_check() {
     'PDE(001) fac00000-fb000000 00400000 -rw'                   \
     '  |-- PTE(000e0) faf00000-fafe0000 000e0000 urw'           \
     '  |-- PTE(00001) fafeb000-fafec000 00001000 -rw'		\
-    'check_slab() succeeded!'					\
     'check_vma_struct() succeeded!'                             \
     'page fault at 0x00000100: K/W [no page found].'            \
     'check_pgfault() succeeded!'                                \

--- a/labcodes_answer/lab8_result/tools/grade.sh
+++ b/labcodes_answer/lab8_result/tools/grade.sh
@@ -338,7 +338,6 @@ default_check() {
     'PDE(001) fac00000-fb000000 00400000 -rw'                   \
     '  |-- PTE(000e0) faf00000-fafe0000 000e0000 urw'           \
     '  |-- PTE(00001) fafeb000-fafec000 00001000 -rw'		\
-    'check_slab() succeeded!'					\
     'check_vma_struct() succeeded!'                             \
     'page fault at 0x00000100: K/W [no page found].'            \
     'check_pgfault() succeeded!'                                \


### PR DESCRIPTION
lab5-lab8 answer的grade.sh里面有关于slab的check, 'check_slab() succeeded!'，而对应的代码里面是cprintf("check_slab() success\n");，输出'check_slab() success'，这样会导致make grade的时候不能得满分。
在练习的代码里面即labcodes里面的grade.sh是没有'check_slab() succeeded!'这样的check，因而考虑是不是可以把labcodes_answer里面对应的删除。